### PR TITLE
Update README.md to refer to 'main' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A project based learning activity for people who are getting started with Git an
 To play the game:
 1. Go to the **Settings** tab of this repository.
 1. Scroll down to the section titled _GitHub Pages_
-1. Select **Master** from the Source drop-down.
+1. Select **main** from the Source drop-down.
 1. Click **Save**.
 1. Navigate to the URL provided in the same section.
 


### PR DESCRIPTION
GitHub recently renamed the default branch from 'master' to 'main'.